### PR TITLE
Fixup defaultSettings to enable SegmentDestination

### DIFF
--- a/src/KraftfulAnalytics.ts
+++ b/src/KraftfulAnalytics.ts
@@ -1,6 +1,13 @@
 import type { EventSender } from "./core/EventSender";
 import { SegmentEventSender } from "./core/SegmentEventSender";
 
+export type KraftfulAnalyticsInitializeOptions = {
+  /**
+   * Whether to show debugging log information or not
+   */
+  debug?: boolean;
+};
+
 /**
  * The KraftfulAnalytics singleton
  */
@@ -8,15 +15,21 @@ export class KraftfulAnalytics {
   private static sender?: EventSender = undefined;
 
   constructor() {
-    throw new Error("KraftfulAnalytics should be instantiated");
+    throw new Error("KraftfulAnalytics should not be instantiated");
   }
 
   /**
    * Initializes the KraftfulAnalytics library using the supplied API key.
    * @param apiKey The API key from your Kraftful analytics account.
+   * @param options The options to initialize with.
    */
-  public static initialize(apiKey: string) {
-    KraftfulAnalytics.initializeWith(new SegmentEventSender(apiKey));
+  public static initialize(
+    apiKey: string,
+    options?: KraftfulAnalyticsInitializeOptions
+  ) {
+    KraftfulAnalytics.initializeWith(
+      new SegmentEventSender(apiKey, { debug: options?.debug })
+    );
   }
 
   /**

--- a/src/core/SegmentEventSender.ts
+++ b/src/core/SegmentEventSender.ts
@@ -4,15 +4,42 @@ import type { EventSender, JsonMap } from "./EventSender";
 
 const KRAFTFUL_INGESTION_URL = "https://analytics-ingestion.kraftful.com/b";
 
+// These are default settings returned from the segment cdnHost as 9/20/2022
+const DEFAULT_SEGMENT_SETTINGS = {
+  unbundledIntegrations: [],
+  addBundledMetadata: true,
+  maybeBundledConfigIds: {},
+  versionSettings: {
+    version: "4.4.7",
+    componentTypes: ["browser"],
+  },
+};
+
 export class SegmentEventSender implements EventSender {
   private client: SegmentClient;
 
-  constructor(apiKey: string) {
+  constructor(
+    apiKey: string,
+    {
+      debug,
+    }: {
+      debug?: boolean;
+    }
+  ) {
     this.client = createClient({
+      defaultSettings: {
+        // @ts-ignore Segment defaultSettings type is bugged, you only pass the integrations part
+        "Segment.io": {
+          apiKey,
+          apiHost: KRAFTFUL_INGESTION_URL,
+          ...DEFAULT_SEGMENT_SETTINGS,
+        },
+      },
       writeKey: apiKey,
       trackAppLifecycleEvents: true,
       flushAt: 10,
       proxy: KRAFTFUL_INGESTION_URL,
+      debug,
     });
   }
 


### PR DESCRIPTION
- Add defaultSettings with @ts-ignore because of @segmentio/analytics-react-native#678
- Add debug option and pass through to SegmentEventSender