### PR TITLE
Subclass SegmentClient to suppress settings warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,8 +76,10 @@
     "preset": "react-native",
     "modulePathIgnorePatterns": [
       "<rootDir>/example/node_modules",
-      "<rootDir>/node_modules/@segment/analytics-react-native/",
       "<rootDir>/lib/"
+    ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!(react-native|@segment)/)"
     ]
   },
   "commitlint": {

--- a/src/__mocks__/@react-native-async-storage/async-storage.js
+++ b/src/__mocks__/@react-native-async-storage/async-storage.js
@@ -1,0 +1,1 @@
+export default from "@react-native-async-storage/async-storage/jest/async-storage-mock";

--- a/src/__mocks__/@segment/sovran-react-native.js
+++ b/src/__mocks__/@segment/sovran-react-native.js
@@ -1,0 +1,6 @@
+const mockApi = {
+  createStore: jest.fn(),
+  registerBridgeStore: jest.fn(),
+};
+
+module.exports = mockApi;

--- a/src/core/SegmentEventSender.ts
+++ b/src/core/SegmentEventSender.ts
@@ -1,5 +1,6 @@
-import { createClient } from "@segment/analytics-react-native";
-import type { SegmentClient } from "@segment/analytics-react-native/lib/typescript/src/analytics";
+import { createClient } from "../segment/client";
+
+import type { KraftfulSegmentClient } from "../segment/analytics";
 import type { EventSender, JsonMap } from "./EventSender";
 
 const KRAFTFUL_INGESTION_URL = "https://analytics-ingestion.kraftful.com/b";
@@ -16,7 +17,7 @@ const DEFAULT_SEGMENT_SETTINGS = {
 };
 
 export class SegmentEventSender implements EventSender {
-  private client: SegmentClient;
+  private client: KraftfulSegmentClient;
 
   constructor(
     apiKey: string,
@@ -44,8 +45,6 @@ export class SegmentEventSender implements EventSender {
   }
 
   track(name: string, properties?: JsonMap) {
-    if (!this.client) return;
-
     this.client.track(name, properties);
   }
 

--- a/src/segment/analytics.ts
+++ b/src/segment/analytics.ts
@@ -1,0 +1,12 @@
+import { SegmentClient } from "@segment/analytics-react-native/src/analytics";
+
+export class KraftfulSegmentClient extends SegmentClient {
+  // Override the fetchSettings method to apply defaultSettings directly
+  async fetchSettings(): Promise<void> {
+    // @ts-ignore private fields should be accessible by inheriting classes
+    if (this.config.defaultSettings) {
+      // @ts-ignore private fields should be accessible by inheriting classes
+      this.store.settings.set(this.config.defaultSettings);
+    }
+  }
+}

--- a/src/segment/client.ts
+++ b/src/segment/client.ts
@@ -1,0 +1,42 @@
+import type { Config } from "@segment/analytics-react-native/src/types";
+import { createLogger } from "@segment/analytics-react-native/src/logger";
+import { SovranStorage } from "@segment/analytics-react-native/src/storage/sovranStorage";
+import { KraftfulSegmentClient } from "./analytics";
+
+const defaultConfig: Config = {
+  writeKey: "",
+  flushAt: 20,
+  flushInterval: 30,
+  maxBatchSize: 1000,
+  trackDeepLinks: false,
+  trackAppLifecycleEvents: false,
+  autoAddSegmentDestination: true,
+};
+
+export const createClient = (config: Config) => {
+  const logger = createLogger();
+  if (typeof config?.debug === "boolean") {
+    if (config.debug) {
+      logger.enable();
+    } else {
+      logger.disable();
+    }
+  }
+  const clientConfig = { ...defaultConfig, ...config };
+
+  const segmentStore = new SovranStorage({
+    storeId: config.writeKey,
+    storePersistor: config.storePersistor,
+  });
+
+  // Use the KraftfulSegmentClient to prevent fetching settings
+  const client = new KraftfulSegmentClient({
+    config: clientConfig,
+    logger,
+    store: segmentStore,
+  });
+
+  client.init();
+
+  return client;
+};


### PR DESCRIPTION
- Update mocks and jest configs because of segment module imports
- Add subclass of SegmentClient that overrides fetchSettings
- Add custom createClient method that instantiates KraftfulSegmentClient
- Update SegmentEventSender to use KraftfulSegmentClient